### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,32 +312,32 @@ const App: React.VFC<{
 
 > 💡 It is recommended to memoize the `watcher` function for better performance.
 
-### `useInnerDispatch`
+### `useInnerReducer`
 
 ```ts
-function useInnerDispatch<A, T>(
+function useInnerReducer<A, T>(
   store: InnerStore<T>,
-  update: (action: A, state: T) => T,
+  reducer: (state: T, action: A) => T,
   compare?: Compare<T>
 ): [T, React.Dispatch<A>]
 
-function useInnerDispatch<A, T>(
+function useInnerReducer<A, T>(
   store: null | undefined | InnerStore<T>,
-  update: (action: A, state: T) => T,
+  reducer: (state: T, action: A) => T,
   compare?: Compare<T>
 ): [null | undefined | T, React.Dispatch<A>]
 ```
 
-A hook that is similar to `React.useDispatch` but for `InnerStore` instances. It subscribes to the store changes and returns the current value and a function to dispatch an action.
+A hook that is similar to `React.useReducer` but for `InnerStore` instances. It subscribes to the store changes and returns the current value and a function to dispatch an action.
 
 - `store` is an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
-- `update` is a function that transforms the current value and the dispatched action into the new value.
+- `reducer` is a function that transforms the current value and the dispatched action into the new value.
 - `[compare]` is an optional [`Compare`][compare] function with strict check (`===`) by default. The store won't update if the new value is comparably equal to the current value.
 
 ```tsx
 type CounterAction = { type: 'INCREMENT' } | { type: 'DECREMENT' }
 
-const counterReducer = (action: CounterAction, state: number) => {
+const counterReducer = (state: number, action: CounterAction) => {
   switch (action.type) {
     case 'INCREMENT':
       return state + 1
@@ -350,7 +350,7 @@ const counterReducer = (action: CounterAction, state: number) => {
 const Counter: React.VFC<{
   store: InnerStore<number>
 }> = React.memo(({ store }) => {
-  const [count, dispatch] = useInnerDispatch(store, counterReducer)
+  const [count, dispatch] = useInnerReducer(store, counterReducer)
 
   return (
     <div>

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ InnerStore<T>#setState(
 ): void
 ```
 
-An `InnerStore` instance's method that sets the value. Each time when the value is changed all of the store's listeners defined with [`InnerStore#subscribe`][inner_store__subscribe] are called.
+An `InnerStore` instance's method that sets the value. Each time when the value is changed all of the store's listeners passed via [`InnerStore#subscribe`][inner_store__subscribe] are called.
 
 - `valueOrTransform` is either the new value or a function that will be applied to the current value before setting.
 - `[compare]` is an optional [`Compare`][compare] function with strict check (`===`) by default. If the new value is comparably equal to the current value neither the value is set nor the listeners are called.
@@ -256,7 +256,7 @@ function useInnerState<T>(
 ): [null | undefined | T, React.Dispatch<React.SetStateAction<T>>]
 ```
 
-The hook that is similar to `React.useState` but for `InnerStore` instances. It subscribes to the store changes and returns the current value and a function to set the value.
+A hook that is similar to `React.useState` but for `InnerStore` instances. It subscribes to the store changes and returns the current value and a function to set the value.
 
 - `store` is an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
 - `[compare]` is an optional [`Compare`][compare] function with strict check (`===`) by default. The store won't update if the new value is comparably equal to the current value.
@@ -283,7 +283,7 @@ const UsernameInput: React.VFC<{
 function useInnerWatch<T>(watcher: () => T, compare?: Compare<T>): T
 ```
 
-The hook that subscribes to all [`InnerStore#getState`][inner_store__get_state] execution involved in the `watcher` call. Due to the mutable nature of `InnerStore` instances a parent component won't be re-rendered when a child's `InnerStore` value is changed. The hook gives a way to watch after deep changes in the store's values and trigger a re-render when the returning value is changed.
+A hook that subscribes to all [`InnerStore#getState`][inner_store__get_state] execution involved in the `watcher` call. Due to the mutable nature of `InnerStore` instances a parent component won't be re-rendered when a child's `InnerStore` value is changed. The hook gives a way to watch after deep changes in the store's values and trigger a re-render when the returning value is changed.
 
 - `watcher` is a function to read only the watching value meaning that it never should call [`InnerStore.of`][inner_store__of], [`InnerStore#clone`][inner_store__clone], [`InnerStore#setState`][inner_store__set_state] or [`InnerStore#subscribe`][inner_store__subscribe] methods inside.
 - `[compare]` is an optional [`Compare`][compare] function with strict check (`===`) by default. The hook won't trigger a re-render when the watching value is comparably equal to the current value.
@@ -297,7 +297,7 @@ const App: React.VFC<{
   state: State
 }> = React.memo(({ state }) => {
   // the component will re-render once the `count` is greater than 5
-  // and once the `count` is less than 5
+  // and once the `count` is less or equal to 5
   const isMoreThanFive = useInnerWatch(() => state.count.getState() > 5)
 
   return (
@@ -328,7 +328,7 @@ function useInnerDispatch<A, T>(
 ): [null | undefined | T, React.Dispatch<A>]
 ```
 
-The hook that is similar to `React.useDispatch` but for `InnerStore` instances. It subscribes to the store changes and returns the current value and a function to dispatch an action.
+A hook that is similar to `React.useDispatch` but for `InnerStore` instances. It subscribes to the store changes and returns the current value and a function to dispatch an action.
 
 - `store` is an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
 - `update` is a function that transforms the current value and the dispatched action into the new value.
@@ -371,7 +371,7 @@ function useInnerUpdate<T>(
 ): React.Dispatch<React.SetStateAction<T>>
 ```
 
-The hooks that returns a function to update the store's value. Might be useful when you need a way to update the store's value without subscribing to its changes.
+A hooks that returns a function to update the store's value. Might be useful when you need a way to update the store's value without subscribing to its changes.
 
 - `store` is an `InnerStore` instance but can be `null` or `undefined` as a bypass when a store might be not defined.
 - `[compare]` is an optional [`Compare`][compare] function with strict check (`===`) by default. The store won't update if the new value is comparably equal to the current value.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint . --config=.eslintrc.prod.json --ext=js,jsx,ts,tsx,md",
     "prettify": "prettier . --write",
-    "typecheck": "tsc -p ./tsconfig.json --noEmit"
+    "typecheck": "tsc -p ./tsconfig.json --noEmit",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -466,12 +466,12 @@ export function useInnerState<T>(
 }
 
 /**
- * A hook that is similar to `React.useDispatch` but for `InnerStore` instances.
+ * A hook that is similar to `React.useReducer` but for `InnerStore` instances.
  * It subscribes to the store changes and returns the current value and a function to set the value.
  * The store won't update if the new value is comparably equal to the current value.
  *
  * @param store an `InnerStore` instance.
- * @param update a function that transforms the current value and the dispatched action into the new value.
+ * @param reducer a function that transforms the current value and the dispatched action into the new value.
  * @param compare a function with strict check (`===`) by default.
  *
  * @see {@link InnerStore.getState}
@@ -479,19 +479,19 @@ export function useInnerState<T>(
  * @see {@link InnerStore.subscribe}
  * @see {@link Compare}
  */
-export function useInnerDispatch<A, T>(
+export function useInnerReducer<T, A>(
   store: InnerStore<T>,
-  update: (action: A, state: T) => T,
+  reducer: (state: T, action: A) => T,
   compare?: Compare<T>
 ): [T, Dispatch<A>]
 
 /**
- * A hook that is similar to `React.useDispatch` but for `InnerStore` instances.
+ * A hook that is similar to `React.useReducer` but for `InnerStore` instances.
  * It subscribes to the store changes and returns the current value and a function to set the value.
  * The store won't update if the new value is comparably equal to the current value.
  *
  * @param store an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
- * @param update a function that transforms the current value and the dispatched action into the new value.
+ * @param reducer a function that transforms the current value and the dispatched action into the new value.
  * @param compare a function with strict check (`===`) by default.
  *
  * @see {@link InnerStore.getState}
@@ -499,19 +499,19 @@ export function useInnerDispatch<A, T>(
  * @see {@link InnerStore.subscribe}
  * @see {@link Compare}
  */
-export function useInnerDispatch<A, T>(
+export function useInnerReducer<T, A>(
   store: null | InnerStore<T>,
-  update: (action: A, state: T) => T,
+  reducer: (state: T, action: A) => T,
   compare?: Compare<T>
 ): [null | T, Dispatch<A>]
 
 /**
- * A hook that is similar to `React.useDispatch` but for `InnerStore` instances.
+ * A hook that is similar to `React.useReducer` but for `InnerStore` instances.
  * It subscribes to the store changes and returns the current value and a function to set the value.
  * The store won't update if the new value is comparably equal to the current value.
  *
  * @param store an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
- * @param update a function that transforms the current value and the dispatched action into the new value.
+ * @param reducer a function that transforms the current value and the dispatched action into the new value.
  * @param compare a function with strict check (`===`) by default.
  *
  * @see {@link InnerStore.getState}
@@ -519,19 +519,19 @@ export function useInnerDispatch<A, T>(
  * @see {@link InnerStore.subscribe}
  * @see {@link Compare}
  */
-export function useInnerDispatch<A, T>(
+export function useInnerReducer<T, A>(
   store: undefined | InnerStore<T>,
-  update: (action: A, state: T) => T,
+  reducer: (state: T, action: A) => T,
   compare?: Compare<T>
 ): [undefined | T, Dispatch<A>]
 
 /**
- * A hook that is similar to `React.useDispatch` but for `InnerStore` instances.
+ * A hook that is similar to `React.useReducer` but for `InnerStore` instances.
  * It subscribes to the store changes and returns the current value and a function to set the value.
  * The store won't update if the new value is comparably equal to the current value.
  *
  * @param store an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
- * @param update a function that transforms the current value and the dispatched action into the new value.
+ * @param reducer a function that transforms the current value and the dispatched action into the new value.
  * @param compare a function with strict check (`===`) by default.
  *
  * @see {@link InnerStore.getState}
@@ -539,29 +539,31 @@ export function useInnerDispatch<A, T>(
  * @see {@link InnerStore.subscribe}
  * @see {@link Compare}
  */
-export function useInnerDispatch<A, T>(
+export function useInnerReducer<T, A>(
   store: null | undefined | InnerStore<T>,
-  update: (action: A, state: T) => T,
+  reducer: (state: T, action: A) => T,
   compare?: Compare<T>
 ): [null | undefined | T, Dispatch<A>]
 
-export function useInnerDispatch<A, T>(
+export function useInnerReducer<T, A>(
   store: null | undefined | InnerStore<T>,
-  update: (action: A, state: T) => T,
+  reducer: (state: T, action: A) => T,
   compare: Compare<T> = isEqual
 ): [null | undefined | T, Dispatch<A>] {
   const [state, setState] = useInnerState(store, compare)
-  const updateRef = useRef(update)
+  const reducerRef = useRef(reducer)
 
   useEffect(() => {
-    updateRef.current = update
-  }, [update])
+    reducerRef.current = reducer
+  }, [reducer])
 
   return [
     state,
     useCallback(
       action => {
-        return setState(currentState => updateRef.current(action, currentState))
+        return setState(currentState =>
+          reducerRef.current(currentState, action)
+        )
       },
       [setState]
     )

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,34 @@ export type Compare<T> = (prev: T, next: T) => boolean
 
 const isEqual = <T>(one: T, another: T): boolean => one === another
 
+type ExtractDirect<T> = T extends InnerStore<infer R> ? R : T
+
+/**
+ * A helper type that shallowly extracts value type from `InnerStore`.
+ */
+export type ExtractInnerState<T> = T extends InnerStore<infer R>
+  ? R
+  : T extends Array<infer R>
+  ? Array<ExtractDirect<R>>
+  : T extends ReadonlyArray<infer R>
+  ? ReadonlyArray<ExtractDirect<R>>
+  : { [K in keyof T]: ExtractDirect<T[K]> }
+
+type ExtractDeepDirect<T> = T extends InnerStore<infer R>
+  ? DeepExtractInnerState<R>
+  : T
+
+/**
+ * A helper that deeply extracts value type from `InnerStore`.
+ */
+export type DeepExtractInnerState<T> = T extends InnerStore<infer R>
+  ? DeepExtractInnerState<R>
+  : T extends Array<infer R>
+  ? Array<ExtractDeepDirect<R>>
+  : T extends ReadonlyArray<infer R>
+  ? ReadonlyArray<ExtractDeepDirect<R>>
+  : { [K in keyof T]: ExtractDeepDirect<T[K]> }
+
 const warning = (message: string): void => {
   /* eslint-disable no-console */
   if (typeof console !== 'undefined' && typeof console.error === 'function') {
@@ -137,8 +165,8 @@ export class InnerStore<T> {
 
   /**
    * A unique key per `InnerStore` instance.
-   * This key is used internally for useInnerWatch
-   * but can be used as the React key for the component.
+   * This key is used internally for `useInnerWatch`
+   * but can be used as the React key property.
    *
    * @see {@link useInnerWatch}
    */
@@ -153,7 +181,8 @@ export class InnerStore<T> {
   /**
    * Clones a `InnerStore` instance.
    *
-   * @param transform optional function that is applied to the value before cloning
+   * @param transform a function that will be applied to the current value before cloning.
+   *
    * @returns new `InnerStore` instance with the same value.
    */
   public clone(transform?: (value: T) => T): InnerStore<T> {
@@ -169,7 +198,7 @@ export class InnerStore<T> {
   /**
    * An `InnerStore` instance's method that returns the current value.
    *
-   * @param transform function that is applied to the value before returning.
+   * @param transform a function that will be applied to the current value before returning.
    */
   public getState<R>(transform: (value: T) => R): R
   public getState<R>(transform?: (value: T) => R): T | R {
@@ -180,18 +209,19 @@ export class InnerStore<T> {
 
   /**
    * Sets the store's value.
-   * Each time when the value is changed all listeners defined with `InnerStore#subscribe` are called.
-   * If the new value is equal to the current value neither the value is set nor listeners are called.
+   * Each time when the value is changed all of the store's listeners defined with `InnerStore#subscribe` are called.
+   * If the new value is comparably equal to the current value neither the value is set nor the listeners are called.
    *
-   * @param transformOrValue either a value or a `transform` function that is applied to the value before setting.
-   * @param compare function that is used to compare the new value with the current value.
+   * @param valueOrTransform either the new value or a function that will be applied to the current value before setting.
+   * @param compare a function with strict check (`===`) by default.
+   *
    * @returns `void` to emphasize that `InnerStore` instances are mutable.
    *
    * @see {@link InnerStore.subscribe}
    * @see {@link Compare}
    */
   public setState(
-    transformOrValue: SetStateAction<T>,
+    valueOrTransform: SetStateAction<T>,
     compare: Compare<T> = isEqual
   ): void {
     if (
@@ -204,9 +234,9 @@ export class InnerStore<T> {
     }
 
     const nextValue =
-      typeof transformOrValue === 'function'
-        ? (transformOrValue as (value: T) => T)(this.value)
-        : transformOrValue
+      typeof valueOrTransform === 'function'
+        ? (valueOrTransform as (value: T) => T)(this.value)
+        : valueOrTransform
 
     if (!compare(this.value, nextValue)) {
       this.value = nextValue
@@ -215,9 +245,13 @@ export class InnerStore<T> {
   }
 
   /**
-   * Adds a listener that is called each time when the value is changed via `InnerStore#setState`.
+   * subscribes to the store's value changes caused by `InnerStore#setState` calls.
    *
-   * @returns an unsubscribe function that can be used to remove the listener.
+   * @param listener a function that will be called on store updates.
+   *
+   * @returns a cleanup function that can be used to unsubscribe the listener.
+   *
+   * @see {@link InnerStore.setState}
    */
   public subscribe(listener: VoidFunction): VoidFunction {
     if (
@@ -241,44 +275,17 @@ export class InnerStore<T> {
   }
 }
 
-type ExtractDirect<T> = T extends InnerStore<infer R> ? R : T
-
-/**
- * A helper type that shallowly extracts value type from `InnerStore`.
- */
-export type ExtractInnerState<T> = T extends InnerStore<infer R>
-  ? R
-  : T extends Array<infer R>
-  ? Array<ExtractDirect<R>>
-  : T extends ReadonlyArray<infer R>
-  ? ReadonlyArray<ExtractDirect<R>>
-  : { [K in keyof T]: ExtractDirect<T[K]> }
-
-type ExtractDeepDirect<T> = T extends InnerStore<infer R>
-  ? DeepExtractInnerState<R>
-  : T
-
-/**
- * A helper that deeply extracts value type from `InnerStore`.
- */
-export type DeepExtractInnerState<T> = T extends InnerStore<infer R>
-  ? DeepExtractInnerState<R>
-  : T extends Array<infer R>
-  ? Array<ExtractDeepDirect<R>>
-  : T extends ReadonlyArray<infer R>
-  ? ReadonlyArray<ExtractDeepDirect<R>>
-  : { [K in keyof T]: ExtractDeepDirect<T[K]> }
-
 /**
  * The hooks that returns a function to update the store's value.
  * Might be useful when you need a way to update the store's value without subscribing to its changes.
- * The store won't update if the new value is equal to the current value.
+ * The store won't update if the new value is comparably equal to the current value.
  *
- * @param store the store to update
- * @param compare function that is used to compare the new value with the current value.
- * @returns
+ * @param store an `InnerStore` instance but can be `null` or `undefined` as a bypass when a store might be not defined.
+ * @param compare a function with strict check (`===`) by default.
  *
+ * @see {@link InnerStore.getState}
  * @see {@link InnerStore.setState}
+ * @see {@link Compare}
  */
 export function useInnerUpdate<T>(
   store: null | undefined | InnerStore<T>,
@@ -298,16 +305,14 @@ export function useInnerUpdate<T>(
 
 /**
  * The hook that subscribes to all `InnerStore#getState` execution involved in the `watcher` call.
- * Due to the mutable nature of `InnerStore` instances a parent component won't be re-rendered
- * when a child's `InnerStore` value is changed.
- * The hook gives a way to watch after deep changes in the store's values
- * and trigger a re-render when the value is changed.
- * The store won't update if the watching value is not changed.
+ * Due to the mutable nature of `InnerStore` instances a parent component won't be re-rendered when a child's `InnerStore` value is changed.
+ * The hook gives a way to watch after deep changes in the store's values and trigger a re-render when the returning value is changed.
  *
- * @param watcher
- * @param compare function that is used to compare the new value with the current value.
+ * @param watcher a function to read only the watching value meaning that it never should call `InnerStore.of`, `InnerStore#clone`, `InnerStore#setState` or `InnerStore#subscribe` methods inside.
+ * @param compare a function with strict check (`===`) by default.
  *
  * @see {@link InnerStore.getState}
+ * @see {@link Compare}
  */
 export function useInnerWatch<T>(
   watcher: () => T,
@@ -377,15 +382,16 @@ export function useInnerWatch<T>(
 
 /**
  * The hook that is similar to `React.useState` but for `InnerStore` instances.
- * It subscribes to the store and returns the current value and a function to set the value.
- * The store won't update if the new value is equal to the current value.
+ * It subscribes to the store changes and returns the current value and a function to set the value.
+ * The store won't update if the new value is comparably equal to the current value.
  *
- * @param store the store to subscribe to.
- * @param compare function that is used to compare the new value with the current value.
+ * @param store an `InnerStore` instance.
+ * @param compare a function with strict check (`===`) by default.
  *
  * @see {@link InnerStore.getState}
  * @see {@link InnerStore.setState}
  * @see {@link InnerStore.subscribe}
+ * @see {@link Compare}
  */
 export function useInnerState<T>(
   store: InnerStore<T>,
@@ -394,15 +400,16 @@ export function useInnerState<T>(
 
 /**
  * The hook that is similar to `React.useState` but for `InnerStore` instances.
- * It subscribes to the store and returns the current value and a function to set the value.
- * The store won't update if the new value is equal to the current value.
+ * It subscribes to the store changes and returns the current value and a function to set the value.
+ * The store won't update if the new value is comparably equal to the current value.
  *
- * @param store the nullable store to subscribe to is a bypass when there is no need to subscribe to the store's changes.
- * @param compare function that is used to compare the new value with the current value.
+ * @param store an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
+ * @param compare a function with strict check (`===`) by default.
  *
  * @see {@link InnerStore.getState}
  * @see {@link InnerStore.setState}
  * @see {@link InnerStore.subscribe}
+ * @see {@link Compare}
  */
 export function useInnerState<T>(
   store: null | InnerStore<T>,
@@ -411,15 +418,16 @@ export function useInnerState<T>(
 
 /**
  * The hook that is similar to `React.useState` but for `InnerStore` instances.
- * It subscribes to the store and returns the current value and a function to set the value.
- * The store won't update if the new value is equal to the current value.
+ * It subscribes to the store changes and returns the current value and a function to set the value.
+ * The store won't update if the new value is comparably equal to the current value.
  *
- * @param store the nullable store to subscribe to is a bypass when there is no need to subscribe to the store's changes.
- * @param compare function that is used to compare the new value with the current value.
+ * @param store an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
+ * @param compare a function with strict check (`===`) by default.
  *
  * @see {@link InnerStore.getState}
  * @see {@link InnerStore.setState}
  * @see {@link InnerStore.subscribe}
+ * @see {@link Compare}
  */
 export function useInnerState<T>(
   store: undefined | InnerStore<T>,
@@ -428,15 +436,16 @@ export function useInnerState<T>(
 
 /**
  * The hook that is similar to `React.useState` but for `InnerStore` instances.
- * It subscribes to the store and returns the current value and a function to set the value.
- * The store won't update if the new value is equal to the current value.
+ * It subscribes to the store changes and returns the current value and a function to set the value.
+ * The store won't update if the new value is comparably equal to the current value.
  *
- * @param store the nullable store to subscribe to is a bypass when there is no need to subscribe to the store's changes.
- * @param compare function that is used to compare the new value with the current value.
+ * @param store an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
+ * @param compare a function with strict check (`===`) by default.
  *
  * @see {@link InnerStore.getState}
  * @see {@link InnerStore.setState}
  * @see {@link InnerStore.subscribe}
+ * @see {@link Compare}
  */
 export function useInnerState<T>(
   store: null | undefined | InnerStore<T>,
@@ -458,18 +467,19 @@ export function useInnerState<T>(
 
 /**
  * The hook that is similar to `React.useDispatch` but for `InnerStore` instances.
- * It subscribes to the store and returns the current value and a function to dispatch an action.
- * It won't trigger a re-render if the new value is equal to the current value.
+ * It subscribes to the store changes and returns the current value and a function to set the value.
+ * The store won't update if the new value is comparably equal to the current value.
  *
- * @param store the store to subscribe to.
- * @param update the function that is used to update the store's value.
- * @param compare function that is used to compare the new value with the current value.
+ * @param store an `InnerStore` instance.
+ * @param update a function that transforms the current value and the dispatched action into the new value.
+ * @param compare a function with strict check (`===`) by default.
  *
  * @see {@link InnerStore.getState}
  * @see {@link InnerStore.setState}
  * @see {@link InnerStore.subscribe}
+ * @see {@link Compare}
  */
-export function useInnerDispatch<T, A>(
+export function useInnerDispatch<A, T>(
   store: InnerStore<T>,
   update: (action: A, state: T) => T,
   compare?: Compare<T>
@@ -477,18 +487,19 @@ export function useInnerDispatch<T, A>(
 
 /**
  * The hook that is similar to `React.useDispatch` but for `InnerStore` instances.
- * It subscribes to the store and returns the current value and a function to dispatch an action.
- * It won't trigger a re-render if the new value is equal to the current value.
+ * It subscribes to the store changes and returns the current value and a function to set the value.
+ * The store won't update if the new value is comparably equal to the current value.
  *
- * @param store the nullable store to subscribe to is a bypass when there is no need to subscribe to the store's changes.
- * @param update the function that is used to update the store's value.
- * @param compare function that is used to compare the new value with the current value.
+ * @param store an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
+ * @param update a function that transforms the current value and the dispatched action into the new value.
+ * @param compare a function with strict check (`===`) by default.
  *
  * @see {@link InnerStore.getState}
  * @see {@link InnerStore.setState}
  * @see {@link InnerStore.subscribe}
+ * @see {@link Compare}
  */
-export function useInnerDispatch<T, A>(
+export function useInnerDispatch<A, T>(
   store: null | InnerStore<T>,
   update: (action: A, state: T) => T,
   compare?: Compare<T>
@@ -496,18 +507,19 @@ export function useInnerDispatch<T, A>(
 
 /**
  * The hook that is similar to `React.useDispatch` but for `InnerStore` instances.
- * It subscribes to the store and returns the current value and a function to dispatch an action.
- * It won't trigger a re-render if the new value is equal to the current value.
+ * It subscribes to the store changes and returns the current value and a function to set the value.
+ * The store won't update if the new value is comparably equal to the current value.
  *
- * @param store the nullable store to subscribe to is a bypass when there is no need to subscribe to the store's changes.
- * @param update the function that is used to update the store's value.
- * @param compare function that is used to compare the new value with the current value.
+ * @param store an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
+ * @param update a function that transforms the current value and the dispatched action into the new value.
+ * @param compare a function with strict check (`===`) by default.
  *
  * @see {@link InnerStore.getState}
  * @see {@link InnerStore.setState}
  * @see {@link InnerStore.subscribe}
+ * @see {@link Compare}
  */
-export function useInnerDispatch<T, A>(
+export function useInnerDispatch<A, T>(
   store: undefined | InnerStore<T>,
   update: (action: A, state: T) => T,
   compare?: Compare<T>
@@ -515,24 +527,25 @@ export function useInnerDispatch<T, A>(
 
 /**
  * The hook that is similar to `React.useDispatch` but for `InnerStore` instances.
- * It subscribes to the store and returns the current value and a function to dispatch an action.
- * It won't trigger a re-render if the new value is equal to the current value.
+ * It subscribes to the store changes and returns the current value and a function to set the value.
+ * The store won't update if the new value is comparably equal to the current value.
  *
- * @param store the nullable store to subscribe to is a bypass when there is no need to subscribe to the store's changes.
- * @param update the function that is used to update the store's value.
- * @param compare function that is used to compare the new value with the current value.
+ * @param store an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
+ * @param update a function that transforms the current value and the dispatched action into the new value.
+ * @param compare a function with strict check (`===`) by default.
  *
  * @see {@link InnerStore.getState}
  * @see {@link InnerStore.setState}
  * @see {@link InnerStore.subscribe}
+ * @see {@link Compare}
  */
-export function useInnerDispatch<T, A>(
+export function useInnerDispatch<A, T>(
   store: null | undefined | InnerStore<T>,
   update: (action: A, state: T) => T,
   compare?: Compare<T>
 ): [null | undefined | T, Dispatch<A>]
 
-export function useInnerDispatch<T, A>(
+export function useInnerDispatch<A, T>(
   store: null | undefined | InnerStore<T>,
   update: (action: A, state: T) => T,
   compare: Compare<T> = isEqual

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ export class InnerStore<T> {
 
   /**
    * Sets the store's value.
-   * Each time when the value is changed all of the store's listeners defined with `InnerStore#subscribe` are called.
+   * Each time when the value is changed all of the store's listeners passed via `InnerStore#subscribe` are called.
    * If the new value is comparably equal to the current value neither the value is set nor the listeners are called.
    *
    * @param valueOrTransform either the new value or a function that will be applied to the current value before setting.
@@ -276,7 +276,7 @@ export class InnerStore<T> {
 }
 
 /**
- * The hooks that returns a function to update the store's value.
+ * A hooks that returns a function to update the store's value.
  * Might be useful when you need a way to update the store's value without subscribing to its changes.
  * The store won't update if the new value is comparably equal to the current value.
  *
@@ -304,7 +304,7 @@ export function useInnerUpdate<T>(
 }
 
 /**
- * The hook that subscribes to all `InnerStore#getState` execution involved in the `watcher` call.
+ * A hook that subscribes to all `InnerStore#getState` execution involved in the `watcher` call.
  * Due to the mutable nature of `InnerStore` instances a parent component won't be re-rendered when a child's `InnerStore` value is changed.
  * The hook gives a way to watch after deep changes in the store's values and trigger a re-render when the returning value is changed.
  *
@@ -381,7 +381,7 @@ export function useInnerWatch<T>(
 }
 
 /**
- * The hook that is similar to `React.useState` but for `InnerStore` instances.
+ * A hook that is similar to `React.useState` but for `InnerStore` instances.
  * It subscribes to the store changes and returns the current value and a function to set the value.
  * The store won't update if the new value is comparably equal to the current value.
  *
@@ -417,7 +417,7 @@ export function useInnerState<T>(
 ): [null | T, Dispatch<SetStateAction<T>>]
 
 /**
- * The hook that is similar to `React.useState` but for `InnerStore` instances.
+ * A hook that is similar to `React.useState` but for `InnerStore` instances.
  * It subscribes to the store changes and returns the current value and a function to set the value.
  * The store won't update if the new value is comparably equal to the current value.
  *
@@ -435,7 +435,7 @@ export function useInnerState<T>(
 ): [undefined | T, Dispatch<SetStateAction<T>>]
 
 /**
- * The hook that is similar to `React.useState` but for `InnerStore` instances.
+ * A hook that is similar to `React.useState` but for `InnerStore` instances.
  * It subscribes to the store changes and returns the current value and a function to set the value.
  * The store won't update if the new value is comparably equal to the current value.
  *
@@ -466,7 +466,7 @@ export function useInnerState<T>(
 }
 
 /**
- * The hook that is similar to `React.useDispatch` but for `InnerStore` instances.
+ * A hook that is similar to `React.useDispatch` but for `InnerStore` instances.
  * It subscribes to the store changes and returns the current value and a function to set the value.
  * The store won't update if the new value is comparably equal to the current value.
  *
@@ -486,7 +486,7 @@ export function useInnerDispatch<A, T>(
 ): [T, Dispatch<A>]
 
 /**
- * The hook that is similar to `React.useDispatch` but for `InnerStore` instances.
+ * A hook that is similar to `React.useDispatch` but for `InnerStore` instances.
  * It subscribes to the store changes and returns the current value and a function to set the value.
  * The store won't update if the new value is comparably equal to the current value.
  *
@@ -506,7 +506,7 @@ export function useInnerDispatch<A, T>(
 ): [null | T, Dispatch<A>]
 
 /**
- * The hook that is similar to `React.useDispatch` but for `InnerStore` instances.
+ * A hook that is similar to `React.useDispatch` but for `InnerStore` instances.
  * It subscribes to the store changes and returns the current value and a function to set the value.
  * The store won't update if the new value is comparably equal to the current value.
  *
@@ -526,7 +526,7 @@ export function useInnerDispatch<A, T>(
 ): [undefined | T, Dispatch<A>]
 
 /**
- * The hook that is similar to `React.useDispatch` but for `InnerStore` instances.
+ * A hook that is similar to `React.useDispatch` but for `InnerStore` instances.
  * It subscribes to the store changes and returns the current value and a function to set the value.
  * The store won't update if the new value is comparably equal to the current value.
  *


### PR DESCRIPTION
Renamed `useInnerDispatch` to `useInnerReducer` to align better with React hook API naming.

Made some changes to README documentation and inline code documentation for the sake of increasing intelligibility.