### PR TITLE
Rename get set hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,10 +362,45 @@ const Counter: React.VFC<{
 })
 ```
 
-### `useInnerUpdate`
+### `useGetInnerState`
 
 ```ts
-function useInnerUpdate<T>(
+function useGetInnerState<T>(
+  store: InnerStore<T>
+): [T, React.Dispatch<React.SetStateAction<T>>]
+
+function useGetInnerState<T>(
+  store: null | undefined | InnerStore<T>
+): [null | undefined | T, React.Dispatch<React.SetStateAction<T>>]
+```
+
+A hooks that subscribes to the store's changes and returns the current value.
+
+- `store` is an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
+
+```tsx
+const App: React.VFC<{
+  left: InnerStore<number>
+  right: InnerStore<number>
+}> = React.memo(({ left }) => {
+  const countLeft = useGetInnerState(left)
+  const countRight = useGetInnerState(right)
+
+  return (
+    <div>
+      <Counter store={left} />
+      <Counter store={right} />
+
+      <p>Sum: {countLeft + countRight}</p>
+    </div>
+  )
+})
+```
+
+### `useSetInnerState`
+
+```ts
+function useSetInnerState<T>(
   store: null | undefined | InnerStore<T>,
   compare?: Compare<T>
 ): React.Dispatch<React.SetStateAction<T>>
@@ -385,13 +420,13 @@ const App: React.VFC<{
   state: State
 }> = React.memo(({ state }) => {
   // the component won't re-render on the count value change
-  const setCount = useInnerUpdate(state.count)
+  const setCount = useSetInnerState(state.count)
 
   return (
     <div>
       <Counter store={state.count} />
 
-      <button onClick={() => setCount(0)>Reset count</button>
+      <button onClick={() => setCount(0)}>Reset count</button>
     </div>
   )
 })

--- a/README.md
+++ b/README.md
@@ -242,41 +242,6 @@ const UsernameInput: React.VFC<{
 })
 ```
 
-### `useInnerState`
-
-```ts
-function useInnerState<T>(
-  store: InnerStore<T>,
-  compare?: Compare<T>
-): [T, React.Dispatch<React.SetStateAction<T>>]
-
-function useInnerState<T>(
-  store: null | undefined | InnerStore<T>,
-  compare?: Compare<T>
-): [null | undefined | T, React.Dispatch<React.SetStateAction<T>>]
-```
-
-A hook that is similar to `React.useState` but for `InnerStore` instances. It subscribes to the store changes and returns the current value and a function to set the value.
-
-- `store` is an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
-- `[compare]` is an optional [`Compare`][compare] function with strict check (`===`) by default. The store won't update if the new value is comparably equal to the current value.
-
-```tsx
-const UsernameInput: React.VFC<{
-  store: InnerStore<string>
-}> = React.memo(({ store }) => {
-  const [username, setUsername] = useInnerState(store)
-
-  return (
-    <input
-      type="text"
-      value={username}
-      onChange={e => setUsername(e.target.value)}
-    />
-  )
-})
-```
-
 ### `useInnerWatch`
 
 ```ts
@@ -312,52 +277,37 @@ const App: React.VFC<{
 
 > 💡 It is recommended to memoize the `watcher` function for better performance.
 
-### `useInnerReducer`
+### `useInnerState`
 
 ```ts
-function useInnerReducer<A, T>(
+function useInnerState<T>(
   store: InnerStore<T>,
-  reducer: (state: T, action: A) => T,
   compare?: Compare<T>
-): [T, React.Dispatch<A>]
+): [T, React.Dispatch<React.SetStateAction<T>>]
 
-function useInnerReducer<A, T>(
+function useInnerState<T>(
   store: null | undefined | InnerStore<T>,
-  reducer: (state: T, action: A) => T,
   compare?: Compare<T>
-): [null | undefined | T, React.Dispatch<A>]
+): [null | undefined | T, React.Dispatch<React.SetStateAction<T>>]
 ```
 
-A hook that is similar to `React.useReducer` but for `InnerStore` instances. It subscribes to the store changes and returns the current value and a function to dispatch an action.
+A hook that is similar to `React.useState` but for `InnerStore` instances. It subscribes to the store changes and returns the current value and a function to set the value.
 
 - `store` is an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
-- `reducer` is a function that transforms the current value and the dispatched action into the new value.
 - `[compare]` is an optional [`Compare`][compare] function with strict check (`===`) by default. The store won't update if the new value is comparably equal to the current value.
 
 ```tsx
-type CounterAction = { type: 'INCREMENT' } | { type: 'DECREMENT' }
-
-const counterReducer = (state: number, action: CounterAction) => {
-  switch (action.type) {
-    case 'INCREMENT':
-      return state + 1
-
-    case 'DECREMENT':
-      return state - 1
-  }
-}
-
-const Counter: React.VFC<{
-  store: InnerStore<number>
+const UsernameInput: React.VFC<{
+  store: InnerStore<string>
 }> = React.memo(({ store }) => {
-  const [count, dispatch] = useInnerReducer(store, counterReducer)
+  const [username, setUsername] = useInnerState(store)
 
   return (
-    <div>
-      <button onClick={() => dispatch({ type: 'DECREMENT' })}>-</button>
-      <span>{count}</span>
-      <button onClick={() => dispatch({ type: 'INCREMENT' })}>+</button>
-    </div>
+    <input
+      type="text"
+      value={username}
+      onChange={e => setUsername(e.target.value)}
+    />
   )
 })
 ```
@@ -425,6 +375,56 @@ const App: React.VFC<{
       <Counter store={state.count} />
 
       <button onClick={() => setCount(0)}>Reset count</button>
+    </div>
+  )
+})
+```
+
+### `useInnerReducer`
+
+```ts
+function useInnerReducer<A, T>(
+  store: InnerStore<T>,
+  reducer: (state: T, action: A) => T,
+  compare?: Compare<T>
+): [T, React.Dispatch<A>]
+
+function useInnerReducer<A, T>(
+  store: null | undefined | InnerStore<T>,
+  reducer: (state: T, action: A) => T,
+  compare?: Compare<T>
+): [null | undefined | T, React.Dispatch<A>]
+```
+
+A hook that is similar to `React.useReducer` but for `InnerStore` instances. It subscribes to the store changes and returns the current value and a function to dispatch an action.
+
+- `store` is an `InnerStore` instance but can be `null` or `undefined` as a bypass when there is no need to subscribe to the store's changes.
+- `reducer` is a function that transforms the current value and the dispatched action into the new value.
+- `[compare]` is an optional [`Compare`][compare] function with strict check (`===`) by default. The store won't update if the new value is comparably equal to the current value.
+
+```tsx
+type CounterAction = { type: 'INCREMENT' } | { type: 'DECREMENT' }
+
+const counterReducer = (state: number, action: CounterAction) => {
+  switch (action.type) {
+    case 'INCREMENT':
+      return state + 1
+
+    case 'DECREMENT':
+      return state - 1
+  }
+}
+
+const Counter: React.VFC<{
+  store: InnerStore<number>
+}> = React.memo(({ store }) => {
+  const [count, dispatch] = useInnerReducer(store, counterReducer)
+
+  return (
+    <div>
+      <button onClick={() => dispatch({ type: 'DECREMENT' })}>-</button>
+      <span>{count}</span>
+      <button onClick={() => dispatch({ type: 'INCREMENT' })}>+</button>
     </div>
   )
 })

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const Username: React.VFC<{
     <input
       type="text"
       value={username}
-      onChange={e => setUsername(e.target.value)}
+      onChange={event => setUsername(event.target.value)}
     />
   )
 })
@@ -236,7 +236,7 @@ const UsernameInput: React.VFC<{
       type="text"
       value={username}
       // all store.subscribe across the app will call their listeners
-      onChange={e => store.setState(e.target.value)}
+      onChange={event => store.setState(event.target.value)}
     />
   )
 })
@@ -306,11 +306,13 @@ const UsernameInput: React.VFC<{
     <input
       type="text"
       value={username}
-      onChange={e => setUsername(e.target.value)}
+      onChange={event => setUsername(event.target.value)}
     />
   )
 })
 ```
+
+> 💡 The hook is a combination of [`useGetInnerState`][use_get_inner_state] and [`useSetInnerState`][use_set_inner_state], so use them if you need to either get/subscribe or set the store's value.
 
 ### `useGetInnerState`
 
@@ -494,4 +496,6 @@ type ArrayOfStores = InnerStore<Array<InnerStore<boolean>>>
 [inner_store__set_state]: #innerstoresetstate
 [inner_store__subscribe]: #innerstoresubscribe
 [use_inner_watch]: #useinnerwatch
+[use_get_inner_state]: #usegetinnerstate
+[use_set_inner_state]: #usesetinnerstate
 [compare]: #compare

--- a/README.md
+++ b/README.md
@@ -365,13 +365,11 @@ const Counter: React.VFC<{
 ### `useGetInnerState`
 
 ```ts
-function useGetInnerState<T>(
-  store: InnerStore<T>
-): [T, React.Dispatch<React.SetStateAction<T>>]
+function useGetInnerState<T>(store: InnerStore<T>): T
 
 function useGetInnerState<T>(
   store: null | undefined | InnerStore<T>
-): [null | undefined | T, React.Dispatch<React.SetStateAction<T>>]
+): null | undefined | T
 ```
 
 A hooks that subscribes to the store's changes and returns the current value.

--- a/README.md
+++ b/README.md
@@ -194,8 +194,6 @@ An `InnerStore` instance's method that sets the value. Each time when the value 
 - `valueOrTransform` is either the new value or a function that will be applied to the current value before setting.
 - `[compare]` is an optional [`Compare`][compare] function with strict check (`===`) by default. If the new value is comparably equal to the current value neither the value is set nor the listeners are called.
 
-> 💬 The method returns `void` to emphasize that `InnerStore` instances are mutable.
-
 ```ts
 const onSubmit = () => {
   signInFormStore.update(state => {
@@ -209,6 +207,8 @@ const onSubmit = () => {
   })
 }
 ```
+
+> 💬 The method returns `void` to emphasize that `InnerStore` instances are mutable.
 
 ### `InnerStore#subscribe`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -450,6 +450,8 @@ export function useGetInnerState<T>(
  * @see {@link InnerStore.getState}
  * @see {@link InnerStore.setState}
  * @see {@link InnerStore.subscribe}
+ * @see {@link useGetInnerState}
+ * @see {@link useSetInnerState}
  * @see {@link Compare}
  */
 export function useInnerState<T>(
@@ -468,6 +470,8 @@ export function useInnerState<T>(
  * @see {@link InnerStore.getState}
  * @see {@link InnerStore.setState}
  * @see {@link InnerStore.subscribe}
+ * @see {@link useGetInnerState}
+ * @see {@link useSetInnerState}
  * @see {@link Compare}
  */
 export function useInnerState<T>(
@@ -486,6 +490,8 @@ export function useInnerState<T>(
  * @see {@link InnerStore.getState}
  * @see {@link InnerStore.setState}
  * @see {@link InnerStore.subscribe}
+ * @see {@link useGetInnerState}
+ * @see {@link useSetInnerState}
  * @see {@link Compare}
  */
 export function useInnerState<T>(
@@ -504,6 +510,8 @@ export function useInnerState<T>(
  * @see {@link InnerStore.getState}
  * @see {@link InnerStore.setState}
  * @see {@link InnerStore.subscribe}
+ * @see {@link useGetInnerState}
+ * @see {@link useSetInnerState}
  * @see {@link Compare}
  */
 export function useInnerState<T>(


### PR DESCRIPTION
Renamed `useInnerUpdate` to `useSetInnerState` and introduce `useGetInnerState`